### PR TITLE
reformat with black

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,11 +1,11 @@
 import os
 
-workers = int(os.environ.get('GUNICORN_PROCESSES', '2'))
-threads = int(os.environ.get('GUNICORN_THREADS', '4'))
+workers = int(os.environ.get("GUNICORN_PROCESSES", "2"))
+threads = int(os.environ.get("GUNICORN_THREADS", "4"))
 
 bind = "0.0.0.0:8080"
-#timeout = 90
+# timeout = 90
 accesslog = "-"
 
-forwarded_allow_ips = '*'
-secure_scheme_headers = {'X-Forwarded-Proto': 'https'}
+forwarded_allow_ips = "*"
+secure_scheme_headers = {"X-Forwarded-Proto": "https"}

--- a/managers/preprocess_data_manager.py
+++ b/managers/preprocess_data_manager.py
@@ -3,7 +3,6 @@ import json
 from managers.synthesize_data_manager import SynthesizeDataManager
 
 
-
 class PreprocessDataManager:
     """Prepares a timeseries data point for graphing
     The class uses a generator that it receives from a data source.  A timeseries data point is received
@@ -11,7 +10,15 @@ class PreprocessDataManager:
     yields a message that contains json data that will be consumed.
 
     """
-    def __init__(self, regress_group_size, points_group_size, col_name, anomaly_std_factor, csv_file_name=None):
+
+    def __init__(
+        self,
+        regress_group_size,
+        points_group_size,
+        col_name,
+        anomaly_std_factor,
+        csv_file_name=None,
+    ):
         """
         :param regress_group_size:  Size in data points of how many points will be included in the linear regression
         calculation.
@@ -31,11 +38,14 @@ class PreprocessDataManager:
         self.points_group_size = points_group_size  # Not used in this first version
         self.col_name = col_name  # col name of feature to plot
         self.file_name = csv_file_name
-        self.init_plot()   # Initialize plot
-        self.regress_buffX = []   # Fixed size buffer.  Size is limited to value of self.regress_plot_size
+        self.init_plot()  # Initialize plot
+        self.regress_buffX = (
+            []
+        )  # Fixed size buffer.  Size is limited to value of self.regress_plot_size
         self.regress_buffY = []
-        self.anomaly_std_factor = anomaly_std_factor  # Defines how many STD that determine an anomaly
-
+        self.anomaly_std_factor = (
+            anomaly_std_factor  # Defines how many STD that determine an anomaly
+        )
 
     def process_point(self):
         """Process one point and put calculated data into a json format.
@@ -65,9 +75,11 @@ class PreprocessDataManager:
         """
         x_old_idx = 0
         y_percent_diff_old = 0
-        plot_color = 'green'
+        plot_color = "green"
         # This generator yields when one point is available from the data source
-        gen = SynthesizeDataManager.csv_line_reader(self.file_name, self.col_name)  # this is a generator
+        gen = SynthesizeDataManager.csv_line_reader(
+            self.file_name, self.col_name
+        )  # this is a generator
         while True:
             # print("rowcounter: {}".format(self.row_counter))
             # Use the generator's next() with a param of None.  If the generator is out of data, next() will
@@ -91,30 +103,57 @@ class PreprocessDataManager:
 
                     regress_start_idx = len(self.regress_buffX) - self.regress_plot_size
                     # Get endpoints of regression line for plotting
-                    x_start_p, x_end_p, y_start_p, y_end_p = self.__get_endpoints_for_regr_line( fit, regress_start_idx)
+                    (
+                        x_start_p,
+                        x_end_p,
+                        y_start_p,
+                        y_end_p,
+                    ) = self.__get_endpoints_for_regr_line(fit, regress_start_idx)
 
-                    y_percent_diffs = self.__calc_percent_diffs(fit)  # Get all percent diffs for all points in regress buffer
-                    std_for_buffer = np.std(y_percent_diffs)   # STD of percent diffs in regress buffer
-                    mean_for_buffer = np.mean(y_percent_diffs) # mean of percent diffs in regress buffer
+                    y_percent_diffs = self.__calc_percent_diffs(
+                        fit
+                    )  # Get all percent diffs for all points in regress buffer
+                    std_for_buffer = np.std(
+                        y_percent_diffs
+                    )  # STD of percent diffs in regress buffer
+                    mean_for_buffer = np.mean(
+                        y_percent_diffs
+                    )  # mean of percent diffs in regress buffer
 
                     # Get percent diff for the current point, which is at the end of the regress_buffX
-                    y_percent_diff = self.calculate_percent_diff_for_curr_point((len(self.regress_buffX) - 1), fit)
-                    if y_percent_diff < (mean_for_buffer - self.anomaly_std_factor * std_for_buffer) or \
-                        (y_percent_diff > (mean_for_buffer + self.anomaly_std_factor * std_for_buffer)):
-                        plot_color = 'red'
+                    y_percent_diff = self.calculate_percent_diff_for_curr_point(
+                        (len(self.regress_buffX) - 1), fit
+                    )
+                    if y_percent_diff < (
+                        mean_for_buffer - self.anomaly_std_factor * std_for_buffer
+                    ) or (
+                        y_percent_diff
+                        > (mean_for_buffer + self.anomaly_std_factor * std_for_buffer)
+                    ):
+                        plot_color = "red"
                     y_percent_diff_new = y_percent_diff
 
                     # add [x_old_point, x_new_point] and [y_percent_diff_old, y_percent_diff_new] and plot_color to json
                     x_old_p = self.regress_buffX[len(self.regress_buffX) - 2]
                     x_new_p = self.regress_buffX[len(self.regress_buffX) - 1]
-                    json_data = self.create_json(timestamp, sensor_val,
-                                                 x_start_p, x_end_p, y_start_p, y_end_p,
-                                                 x_old_p, x_new_p, y_percent_diff_old, y_percent_diff,
-                                                 plot_color, self.row_counter)
+                    json_data = self.create_json(
+                        timestamp,
+                        sensor_val,
+                        x_start_p,
+                        x_end_p,
+                        y_start_p,
+                        y_end_p,
+                        x_old_p,
+                        x_new_p,
+                        y_percent_diff_old,
+                        y_percent_diff,
+                        plot_color,
+                        self.row_counter,
+                    )
                     # print("Regress slope: {}   Regress intspt: {}".format(fit[0],fit[1]))
-                    print("Server json data: {} ".format(json_data) )
+                    print("Server json data: {} ".format(json_data))
                     y_percent_diff_old = y_percent_diff_new
-                    plot_color = 'green'
+                    plot_color = "green"
                     self.row_counter = self.row_counter + self.points_group_size
                     yield "event: update\ndata: " + json.dumps(json_data) + "\n\n"
                 else:
@@ -124,8 +163,20 @@ class PreprocessDataManager:
                     # regression line.  So while we are waiting for the buffer window to fill, we still plot
                     # the sensor data as points.
                     self.row_counter = self.row_counter + self.points_group_size
-                    json_data = self.create_json(timestamp, sensor_val, None, None, None, None, None,
-                                                 None, None, None, None, None)
+                    json_data = self.create_json(
+                        timestamp,
+                        sensor_val,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
                     yield "event: update\ndata: " + json.dumps(json_data) + "\n\n"
                     next(gen)
 
@@ -145,7 +196,6 @@ class PreprocessDataManager:
         x_end_p = self.regress_buffX[x_end_idx]
         y_end_p = x_end_idx * regr_fit[0] + regr_fit[1]
         return x_start_p, x_end_p, y_start_p, y_end_p
-
 
     def __calc_percent_diffs(self, regr_fit):
         """Calculate y diffs between data points and regression line for all points in the buffer
@@ -189,7 +239,7 @@ class PreprocessDataManager:
         xarr_temp = xarr.copy()
         yarr_temp = yarr.copy()  # list of strings representing floats
 
-        xarr_temp.pop()      # Remove current point since it may be an anomaly.
+        xarr_temp.pop()  # Remove current point since it may be an anomaly.
         yarr_temp.pop()
         float_list = []  # Must convert yarr_temp to numpy array of floats.
         for item in yarr_temp:
@@ -197,13 +247,25 @@ class PreprocessDataManager:
         yarr_converted = np.array(float_list)
         # Make temp array of integers that serve as x index for points in the buffer.
         numericX = np.arange(len(xarr_temp))
-        fit = np.polyfit(numericX, yarr_converted, 1)   # deg of 1
+        fit = np.polyfit(numericX, yarr_converted, 1)  # deg of 1
 
         return fit
 
-    def create_json(self, timestamp, sensor_val,
-                        x1, x2, y1, y2, x_old_p, x_new_p, y_percent_diff_old,
-                        y_percent_diff, plot_color, row_counter):
+    def create_json(
+        self,
+        timestamp,
+        sensor_val,
+        x1,
+        x2,
+        y1,
+        y2,
+        x_old_p,
+        x_new_p,
+        y_percent_diff_old,
+        y_percent_diff,
+        plot_color,
+        row_counter,
+    ):
         """Put all parameters into a JSON string
 
         :param timestamp:
@@ -220,18 +282,18 @@ class PreprocessDataManager:
         :param row_counter:
         :return: Json string
         """
-        plot_dict = {'plotpoint': [timestamp, sensor_val],
-                     'regress': {'xs': [x1, x2],
-                                 'ys': [y1, y2]
-                                 },
-                     'calc': {'x1': x_old_p,
-                              'x2': x_new_p,
-                              'y_diff1': y_percent_diff_old,
-                              'y_diff2': y_percent_diff,
-                              'plot_color': plot_color,
-                              'row_counter': row_counter
-                              }
-                     }
+        plot_dict = {
+            "plotpoint": [timestamp, sensor_val],
+            "regress": {"xs": [x1, x2], "ys": [y1, y2]},
+            "calc": {
+                "x1": x_old_p,
+                "x2": x_new_p,
+                "y_diff1": y_percent_diff_old,
+                "y_diff2": y_percent_diff,
+                "plot_color": plot_color,
+                "row_counter": row_counter,
+            },
+        }
         return plot_dict
 
     def init_plot(self):
@@ -243,4 +305,3 @@ class PreprocessDataManager:
         """Currently not used"""
         print("PreprocessDataManager.stop_plot()")
         yield "event: stop\ndata: " + "none" + "\n\n"
-

--- a/managers/synthesize_data_manager.py
+++ b/managers/synthesize_data_manager.py
@@ -3,9 +3,8 @@ import time
 
 
 class SynthesizeDataManager:
-    """Used as a  data source that periodically yields timeseries data points
+    """Used as a  data source that periodically yields timeseries data points"""
 
-    """
     @staticmethod
     def csv_line_reader(file_name, col_name):
         """Use data from a csv to periodically yield a row of data
@@ -16,10 +15,9 @@ class SynthesizeDataManager:
         ..notes:: This static method has no return.  Instead, it yields a row of data that has been read from
         a data source.
         """
-        with open(file_name, 'r') as read_obj:
+        with open(file_name, "r") as read_obj:
             dict_reader = DictReader(read_obj)
             for row in dict_reader:
                 # print("row in reader: {}".format(row))
                 time.sleep(1 / 10)
-                yield [row['timestamp'], row[col_name]]
-
+                yield [row["timestamp"], row[col_name]]

--- a/wsgi.py
+++ b/wsgi.py
@@ -7,31 +7,36 @@ app = Flask(__name__)
 # https://docs.openshift.com/container-platform/3.11/using_images/s2i_images/python.html#using-images-python-configuration
 application = app
 
-@app.route('/')
+
+@app.route("/")
 def main():
-    return render_template('main.html')
+    return render_template("main.html")
 
 
-@app.route('/generateData')
+@app.route("/generateData")
 def generate_data():
     #  col_name, points_group_size, regress_group_size, anomaly_std_factor are all obtained
     # from the form in the user interface.
     regression_group_size = 40
     points_group_size = 1
-    #col_name = 'sensor_34'
-    col_name = 'pressure'
+    # col_name = 'sensor_34'
+    col_name = "pressure"
     anomaly_std_factor = 4
-    file_name = 'static/casing1_corrected_scaled.csv'
-    #file_name = 'static/slice0_scaled.csv'
+    file_name = "static/casing1_corrected_scaled.csv"
+    # file_name = 'static/slice0_scaled.csv'
 
-    pdm = PreprocessDataManager(regression_group_size,
-                                points_group_size, col_name, anomaly_std_factor,
-                                csv_file_name=file_name)
+    pdm = PreprocessDataManager(
+        regression_group_size,
+        points_group_size,
+        col_name,
+        anomaly_std_factor,
+        csv_file_name=file_name,
+    )
     pdm.process_point()
-    return Response(pdm.process_point(), mimetype='text/event-stream')
+    return Response(pdm.process_point(), mimetype="text/event-stream")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True, port=8080, host="0.0.0.0")  # nosec
 
 # run gunicorn manually


### PR DESCRIPTION
Reformat all code with black.

Black is a code formater for python that is designed to help keep code styles cleaner.  There is no functional change to any code.

It helps to enforce some pep8 best practices and overall helps to keep code consistent.

Black is a great tool to run while you are coding.  You can install it with the following:

```sh
pip install black
```

To run black on your code you can use the following command:

```sh
black .
```

You can also setup VSCode to auto apply black for you when you save a file so you never have to run the command.

In the root of your project create the file `.vscode/settings.json` with the following:

```json
{
    "python.formatting.provider": "black",
    "editor.formatOnSave": true
}
```

DO NOT add black to your requirements.txt file.  This is a dev tool only and should not be added to the built container.